### PR TITLE
[traefik-ingress] Added optional strict sni for default tlsOption

### DIFF
--- a/charts/traefik-ingress/templates/default.tlsoptions.yaml
+++ b/charts/traefik-ingress/templates/default.tlsoptions.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "mia-traefik-ingress.labels" . | nindent 4 }}
 spec:
+  strictSni: {{ .Values.tlsStrictSni }}
   {{- include "mia-traefik-ingress.defaultTlsOptionSpec" . | nindent 2 }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -15,6 +16,7 @@ metadata:
   labels:
     {{- include "mia-traefik-ingress.labels" . | nindent 4 }}
 spec:
+  strictSni: true
   {{- include "mia-traefik-ingress.oldTlsOptionSpec" . | nindent 2 }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -24,6 +26,7 @@ metadata:
   labels:
     {{- include "mia-traefik-ingress.labels" . | nindent 4 }}
 spec:
+  strictSni: true
   {{- include "mia-traefik-ingress.intermediateTlsOptionSpec" . | nindent 2 }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -33,5 +36,6 @@ metadata:
   labels:
     {{- include "mia-traefik-ingress.labels" . | nindent 4 }}
 spec:
+  strictSni: true
   {{- include "mia-traefik-ingress.modernTlsOptionSpec" . | nindent 2 }}
 {{- end -}}

--- a/charts/traefik-ingress/templates/definitions/_tlsOptionSpec.tpl
+++ b/charts/traefik-ingress/templates/definitions/_tlsOptionSpec.tpl
@@ -3,7 +3,6 @@
 Create the base for the TLSOption that is shared between spec.
 */}}
 {{- define "mia-traefik-ingress.baseTlsOptionSpec" -}}
-sniStrict: true
 curvePreferences:
   - "X25519"
   - "CurveP384"

--- a/charts/traefik-ingress/values.schema.json
+++ b/charts/traefik-ingress/values.schema.json
@@ -25,6 +25,10 @@
       "type": "string",
       "enum": ["modern", "intermediate", "old"]
     },
+    "tlsStrictSni": {
+      "description": "Select if the default TLSOptions has strict sni enabled",
+      "type": "boolean"
+    },
     "podSecurityPolicyEnabled": {
       "description": "Enable the Pod Security Policy for allowing the execution of the traefik pods",
       "type": "boolean"

--- a/charts/traefik-ingress/values.yaml
+++ b/charts/traefik-ingress/values.yaml
@@ -8,6 +8,8 @@ applicationName: ""
 logLevel: "WARN"
 # Select the default TLSOptions to deploy, accept only "modern", "intermediate" or "old" value
 tlsOption: "intermediate"
+# Select if the default TLSOptions has strict sni enabled
+tlsStrictSni: true
 # Enable the Pod Security Policy for allowing the execution of the traefik pods
 podSecurityPolicyEnabled: false
 # Set as default ingressClass. Ignored if Traefik version < 2.3 / kubernetes < 1.18.x


### PR DESCRIPTION
# Description of the change

Added optional `strictSni` for default `tlsOption`.

## Benefits

This allows a default * certificate for all the routes, if a custom one is needed simply specify a tlsOption for the route.

## Checklist
<!-- Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] Variables are validated in the `values.schema.json` of the chart
- [X] Title of the PR starts with chart name (e.g. `[chart-name]`)
