### PR TITLE
[ALL-CHARTS] fix: aligned node selector to standard

### DIFF
--- a/charts/logging/Chart.yaml
+++ b/charts/logging/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logging-operator
-version: 3.8.3
+version: 4.0.0
 kubeVersion: ">= 1.16.0-0"
 appVersion: 3.17.6
 description: "A Kubernetes logging stack based on Logging Operator"

--- a/charts/logging/Chart.yaml
+++ b/charts/logging/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: logging-operator
-version: 3.8.2
+version: 3.8.3
 kubeVersion: ">= 1.16.0-0"
 appVersion: 3.17.6
 description: "A Kubernetes logging stack based on Logging Operator"

--- a/charts/logging/templates/default.logging.yaml
+++ b/charts/logging/templates/default.logging.yaml
@@ -76,7 +76,7 @@ spec:
     affinity:
       {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.defaultLogging.fluentbit.nodeSelectors }}
+    {{- with .Values.defaultLogging.fluentbit.nodeSelector }}
     nodeSelector:
       {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -139,7 +139,7 @@ spec:
     affinity:
       {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.defaultLogging.fluentd.nodeSelectors }}
+    {{- with .Values.defaultLogging.fluentd.nodeSelector }}
     nodeSelector:
       {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/logging/templates/deployment.yaml
+++ b/charts/logging/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.deploy.nodeSelectors }}
+      {{- with .Values.deploy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/logging/values.schema.json
+++ b/charts/logging/values.schema.json
@@ -57,7 +57,7 @@
           "description": "Pod affinity to add to the deployment",
           "type": "object"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deployment",
           "type": "object"
         },

--- a/charts/logging/values.yaml
+++ b/charts/logging/values.yaml
@@ -38,7 +38,7 @@ deploy:
   # If you wanto to add pod affinity rules for the logging operator pods fill this variable
   affinity: {}
   # If you have the necessity to run logging operator only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that logging operator will run fill
   # this variable
   tolerations: []
@@ -78,7 +78,7 @@ defaultLogging:
     # If you wanto to add pod affinity rules for the logging operator pods fill this variable
     affinity: {}
     # If you have the necessity to run logging operator only on specific labeled nodes fill this variables
-    nodeSelectors: {}
+    nodeSelector: {}
     # If you have to ignore particular taints on nodes where you want that logging operator will run fill
     # this variable
     tolerations: []
@@ -105,7 +105,7 @@ defaultLogging:
     # If you wanto to add pod affinity rules for the logging operator pods fill this variable
     affinity: {}
     # If you have the necessity to run logging operator only on specific labeled nodes fill this variables
-    nodeSelectors: {}
+    nodeSelector: {}
     # If you have to ignore particular taints on nodes where you want that logging operator will run fill
     # this variable
     tolerations: []

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: monitoring
-version: 1.3.2
+version: 2.0.0
 kubeVersion: ">= 1.20.0-0"
 appVersion: "v0.56.2"
 description: "A Kubernetes monitoring stack based on Prometheus Operator"

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: monitoring
-version: 1.3.1
+version: 1.3.2
 kubeVersion: ">= 1.20.0-0"
 appVersion: "v0.56.2"
 description: "A Kubernetes monitoring stack based on Prometheus Operator"

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -23,5 +23,5 @@ maintainers:
   - name: "Giorgia Fiscaletti"
     url: https://github.com/fiscafusca
 icon: "https://raw.githubusercontent.com/prometheus-operator/prometheu\
-  s-operator/master/Documentation/logos/prometheus-operator-logo.png"
+       s-operator/master/Documentation/logos/prometheus-operator-logo.png"
 deprecated: false

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -22,5 +22,6 @@ maintainers:
     url: https://github.com/ddellarocca
   - name: "Giorgia Fiscaletti"
     url: https://github.com/fiscafusca
-icon: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/Documentation/logos/prometheus-operator-logo.png
+icon: "https://raw.githubusercontent.com/prometheus-operator/prometheu\
+  s-operator/master/Documentation/logos/prometheus-operator-logo.png"
 deprecated: false

--- a/charts/monitoring/templates/deployment.yaml
+++ b/charts/monitoring/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.deploy.nodeSelectors }}
+      {{- with .Values.deploy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/monitoring/templates/hooks/create-certificates.yaml
+++ b/charts/monitoring/templates/hooks/create-certificates.yaml
@@ -44,7 +44,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.deploy.nodeSelectors }}
+      {{- with .Values.deploy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/monitoring/templates/hooks/patch-webhooks.yaml
+++ b/charts/monitoring/templates/hooks/patch-webhooks.yaml
@@ -44,7 +44,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.deploy.nodeSelectors }}
+      {{- with .Values.deploy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/monitoring/templates/kube-state-metrics/deployment.yaml
+++ b/charts/monitoring/templates/kube-state-metrics/deployment.yaml
@@ -78,7 +78,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.kubeStateMetrics.nodeSelectors }}
+      {{- with .Values.kubeStateMetrics.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/monitoring/templates/node-exporter/daemonset.yaml
+++ b/charts/monitoring/templates/node-exporter/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeExporter.nodeSelectors }}
+      {{- with .Values.nodeExporter.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/monitoring/values.schema.json
+++ b/charts/monitoring/values.schema.json
@@ -62,7 +62,7 @@
           "description": "Pod affinity to add to the deployment",
           "type": "object"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deployment",
           "type": "object"
         },
@@ -143,7 +143,7 @@
           "description": "The resource block for the Prometheus container",
           "type": "object"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deployment",
           "type": "object"
         },
@@ -254,7 +254,7 @@
           "description": "The resource block for the Alertmanager container",
           "type": "object"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deployment",
           "type": "object"
         },
@@ -312,7 +312,7 @@
           "description": "Pod affinity to add to the deamonset",
           "type": "object"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deamonset",
           "type": "object"
         },
@@ -357,7 +357,7 @@
           "description": "Pod affinity to add to the deamonset",
           "type": "object"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deamonset",
           "type": "object"
         },

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -39,7 +39,7 @@ deploy:
   # If you wanto to add pod affinity rules for the prometheus operator pods fill this variable
   affinity: {}
   # If you have the necessity to run prometheus operator only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that prometheus operator will run fill
   # this variable
   tolerations: []
@@ -82,7 +82,7 @@ prometheus:
     #   memory: "200Mi"
 
   # If you have the necessity to run prometheus only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that prometheus will run fill
   # this variable
   tolerations: []
@@ -133,7 +133,7 @@ alertmanager:
     #   memory: "200Mi"
 
   # If you have the necessity to run alertmanager only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that alertmanager will run fill
   # this variable
   tolerations: []
@@ -169,7 +169,7 @@ nodeExporter:
   # If you wanto to add pod affinity rules for the node exporter pods fill this variable
   affinity: {}
   # If you have the necessity to run node exporter only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that node exporter will run fill
   # this variable
   tolerations:
@@ -197,7 +197,7 @@ kubeStateMetrics:
   # If you wanto to add pod affinity rules for the node exporter pods fill this variable
   affinity: {}
   # If you have the necessity to run node exporter only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that node exporter will run fill
   # this variable
   tolerations: []

--- a/charts/traefik-ingress/Chart.yaml
+++ b/charts/traefik-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik-ingress
-version: 1.5.7
+version: 1.5.8
 kubeVersion: ">= 1.17.0-0"
 appVersion: 2.7.0
 description: "A Kubernetes Ingress Controller based on Traefik"

--- a/charts/traefik-ingress/Chart.yaml
+++ b/charts/traefik-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik-ingress
-version: 1.5.8
+version: 2.0.0
 kubeVersion: ">= 1.17.0-0"
 appVersion: 2.7.0
 description: "A Kubernetes Ingress Controller based on Traefik"

--- a/charts/traefik-ingress/templates/deployment.yaml
+++ b/charts/traefik-ingress/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         fsGroup: 12000
       affinity:
         {{- include "mia-traefik-ingress.podAffinity" . | nindent 8 }}
-      {{- with .Values.deploy.nodeSelectors }}
+      {{- with .Values.deploy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/traefik-ingress/values.schema.json
+++ b/charts/traefik-ingress/values.schema.json
@@ -97,7 +97,7 @@
           "description": "Name of kuberntes secrets to use for repository authentication",
           "type": "array"
         },
-        "nodeSelectors": {
+        "nodeSelector": {
           "description": "Node selectors to add to the deployment",
           "type": "object"
         },

--- a/charts/traefik-ingress/values.yaml
+++ b/charts/traefik-ingress/values.yaml
@@ -52,7 +52,7 @@ deploy:
   #     memory: "100Mi"
 
   # If you have the necessity to run traefik only on specific labeled nodes fill this variables
-  nodeSelectors: {}
+  nodeSelector: {}
   # If you have to ignore particular taints on nodes where you want that traefik will run fill
   # this variable
   tolerations: []


### PR DESCRIPTION
# Description of the change

Change `nodeSelectors` to `nodeSelector` in order to match the standard.

## Checklist
<!-- Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] Variables are documented in the `README.md` file of the chart
- [X] Variables are validated in the `values.schema.yaml` of the chart
- [X] Title of the PR starts with chart name (e.g. `[chart-name]`)
- [X] Update the version inside the `Chart.yaml` file of the chart
