### PR TITLE
[monitoring]: add additional relabel config

### DIFF
--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: monitoring
-version: 2.1.1
+version: 2.1.2
 kubeVersion: ">= 1.20.0-0"
 appVersion: "v0.59.2"
 description: "A Kubernetes monitoring stack based on Prometheus Operator"

--- a/charts/monitoring/templates/definitions/_prometheus.tpl
+++ b/charts/monitoring/templates/definitions/_prometheus.tpl
@@ -95,6 +95,9 @@ Create the name for the additional scraping config secret
         - "__tmp_hash"
       regex: "$(SHARD)"
       action: "keep"
+    {{- with .Values.prometheus.additionalRelabelConfigs }}
+    {{- toYaml . | nindent 4 -}}
+    {{ end -}}
 {{- if .Values.prometheus.additionalScrapeConfigs }}
 {{ .Values.prometheus.additionalScrapeConfigs }}
 {{- end -}}

--- a/charts/monitoring/values.schema.json
+++ b/charts/monitoring/values.schema.json
@@ -155,6 +155,14 @@
           "description": "The remote write block that can be set on the prometheus CRD",
           "type": "array"
         },
+        "additionalScrapeConfigs": {
+          "description": "Additional scrape job",
+          "type": "string"
+        },
+        "additionalRelabelConfigs": {
+          "description": "Additional relabel configs that will be appended to the default job",
+          "type": "array"
+        },
         "enableDNSMonitor": {
           "description": "Enabel the DNS service metrics monitor",
           "type": "boolean"

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -93,6 +93,8 @@ prometheus:
 
   additionalScrapeConfigs: ""
 
+  additionalRelabelConfigs: []
+
   # Enable the monitor for the DNS metrics
   enableDNSMonitor: true
 


### PR DESCRIPTION
# Description of the change

Add the possibility to add additional relabel configs to the default job without having to create a new job.

## Checklist
<!-- Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] Variables are documented in the `README.md` file of the chart
- [X] Variables are validated in the `values.schema.yaml` of the chart
- [X] Title of the PR starts with chart name (e.g. `[chart-name]`)
- [X] Update the version inside the `Chart.yaml` file of the chart
